### PR TITLE
Fix mobile footer media query closing brace

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -360,8 +360,6 @@ a:focus-visible {
   .contact__submit {
     justify-self: stretch;
   }
-}
-
   .page__footer-inner {
     justify-content: center;
     text-align: center;


### PR DESCRIPTION
## Summary
- keep the max-width: 720px media query open through the footer rules by removing the stray closing brace

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e16d784fa4832492ee2383ad0284b8