### PR TITLE
Widen hero card and repair mobile media query

### DIFF
--- a/src/components/RotatingText.css
+++ b/src/components/RotatingText.css
@@ -3,7 +3,7 @@
   display: inline-grid;
   align-items: center;
   justify-items: center;
-  min-width: 12ch;
+  min-width: 14ch;
   font-weight: 600;
   color: #0f2725;
   text-transform: lowercase;

--- a/src/index.css
+++ b/src/index.css
@@ -175,7 +175,8 @@ a:focus-visible {
 
 .hero__card {
   position: relative;
-  width: min(100%, 520px);
+  width: 100%;
+  max-width: clamp(520px, 60vw, 680px);
   padding: clamp(2.6rem, 6vw, 4rem);
   border-radius: 28px;
   background: rgba(255, 255, 255, 0.88);
@@ -205,6 +206,7 @@ a:focus-visible {
   flex-wrap: wrap;
   gap: 0.6rem;
   align-items: center;
+  justify-content: center;
 }
 
 .hero__meta {
@@ -352,6 +354,10 @@ a:focus-visible {
     justify-content: center;
   }
 
+  .hero__card {
+    max-width: min(100%, 520px);
+  }
+
   .hero__heading {
     justify-content: center;
   }
@@ -359,7 +365,6 @@ a:focus-visible {
   .contact__submit {
     justify-self: stretch;
   }
-}
 
   .page__footer-inner {
     justify-content: center;


### PR DESCRIPTION
## Summary
- widen the hero card container so the rotating keyword has more balanced spacing on desktop
- enlarge the rotating text base width and keep the hero card narrower on small screens
- fix the mobile footer media query by removing the stray closing brace

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e16c2252fc8324919e16ffb90d017b