### PR TITLE
Add pixel blast background and align section anchors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import LiquidBackground from './components/LiquidBackground.jsx';
+import PixelBlast from './components/PixelBlast.jsx';
 import RotatingText from './components/RotatingText.jsx';
 import ScrollStack from './components/ScrollStack.jsx';
 import MasonryGallery from './components/MasonryGallery.jsx';
@@ -109,6 +110,7 @@ const App = () => {
   return (
     <div className="page">
       <LiquidBackground />
+      <PixelBlast />
       <header className="page__header">
         <div className="page__header-inner">
           <span className="page__brand">Imagicity</span>
@@ -138,7 +140,8 @@ const App = () => {
         <section className="section about" id="about" aria-labelledby="about-heading">
           <div className="section__header">
             <span className="section__eyebrow">About</span>
-            <h2 className="section__title" id="about-heading">We choreograph magnetic brand worlds</h2>
+            <h2 className="section__title" id="about-heading">About</h2>
+            <p className="section__subtitle">We choreograph magnetic brand worlds.</p>
           </div>
           <div className="about__content">
             <p>
@@ -157,9 +160,10 @@ const App = () => {
         <section className="section services" id="services" aria-labelledby="services-heading">
           <div className="section__header">
             <span className="section__eyebrow">Services</span>
-            <h2 className="section__title" id="services-heading">Momentum engines with a pulse</h2>
+            <h2 className="section__title" id="services-heading">Services</h2>
             <p className="section__subtitle">
-              We build living systems that shimmer, swirl, and surge with your audience.
+              Momentum engines with a pulse. We build living systems that shimmer, swirl, and surge with your
+              audience.
             </p>
           </div>
           <p className="services__manifesto">
@@ -173,15 +177,17 @@ const App = () => {
         <section className="section work" id="work" aria-labelledby="work-heading">
           <div className="section__header">
             <span className="section__eyebrow">Selected Work</span>
-            <h2 className="section__title" id="work-heading">Signals we set loose</h2>
+            <h2 className="section__title" id="work-heading">Work</h2>
+            <p className="section__subtitle">Signals we set loose.</p>
           </div>
           <MasonryGallery items={workProjects} />
         </section>
 
         <section className="section blog" id="blog" aria-labelledby="blog-heading">
           <div className="section__header">
-            <span className="section__eyebrow">Insights</span>
-            <h2 className="section__title" id="blog-heading">Field notes from the future</h2>
+            <span className="section__eyebrow">Blog</span>
+            <h2 className="section__title" id="blog-heading">Blog</h2>
+            <p className="section__subtitle">Field notes from the future.</p>
           </div>
           <BlogCarousel items={blogPosts} />
         </section>
@@ -189,8 +195,9 @@ const App = () => {
         <section className="section contact" id="contact" aria-labelledby="contact-heading">
           <div className="contact__panel">
             <div className="contact__intro">
-              <p className="contact__eyebrow">Partnerships</p>
-              <h2 className="contact__title" id="contact-heading">Let&apos;s Connect Today</h2>
+              <p className="contact__eyebrow">Contact</p>
+              <h2 className="contact__title" id="contact-heading">Contact</h2>
+              <p className="contact__subtitle">Let&apos;s connect today.</p>
               <p>
                 Tell us about the future you&apos;re chasing and we&apos;ll shape the momentum plan together.
               </p>

--- a/src/components/PixelBlast.css
+++ b/src/components/PixelBlast.css
@@ -1,0 +1,84 @@
+.pixel-blast {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  overflow: hidden;
+  display: block;
+  mix-blend-mode: screen;
+}
+
+.pixel-blast::before {
+  content: '';
+  position: absolute;
+  inset: -25%;
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.32), transparent 72%);
+  filter: blur(120px);
+  opacity: 0.5;
+  animation: pixel-blast-pulse 16s ease-in-out infinite;
+}
+
+.pixel-blast span {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: var(--size);
+  height: var(--size);
+  border-radius: 22%;
+  background: conic-gradient(from 45deg, hsla(var(--hue), 82%, 72%, 0.9), hsla(calc(var(--hue) + 40), 86%, 64%, 0.65));
+  box-shadow: 0 0 12px hsla(var(--hue), 90%, 72%, 0.45), 0 0 24px hsla(var(--hue), 88%, 78%, 0.35);
+  transform: rotate(var(--angle)) translateX(0) scale(0.35);
+  transform-origin: center;
+  opacity: 0;
+  filter: saturate(120%);
+  animation: pixel-blast-shoot var(--duration) linear infinite;
+  animation-delay: var(--delay);
+}
+
+.pixel-blast span::after {
+  content: '';
+  position: absolute;
+  inset: 30%;
+  border-radius: inherit;
+  background: rgba(255, 255, 255, 0.5);
+  filter: blur(6px);
+  opacity: 0.6;
+}
+
+@keyframes pixel-blast-shoot {
+  0% {
+    opacity: 0;
+    transform: rotate(var(--angle)) translateX(0) scale(0.35);
+  }
+  12% {
+    opacity: 0.85;
+  }
+  55% {
+    opacity: 0.65;
+  }
+  100% {
+    opacity: 0;
+    transform: rotate(var(--angle)) translateX(var(--distance)) scale(1.05);
+  }
+}
+
+@keyframes pixel-blast-pulse {
+  0%,
+  100% {
+    opacity: 0.28;
+    transform: scale(1);
+  }
+  45% {
+    opacity: 0.52;
+    transform: scale(1.1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pixel-blast,
+  .pixel-blast::before,
+  .pixel-blast span {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/src/components/PixelBlast.jsx
+++ b/src/components/PixelBlast.jsx
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+import './PixelBlast.css';
+
+const PixelBlast = ({ shards = 42 }) => {
+  const particles = useMemo(
+    () =>
+      Array.from({ length: shards }, (_, index) => ({
+        angle: (index / shards) * 360,
+        distance: 26 + Math.random() * 48,
+        delay: Math.random() * 4,
+        duration: 5.5 + Math.random() * 4.5,
+        size: 12 + Math.random() * 22,
+        hue: 160 + Math.random() * 90,
+      })),
+    [shards]
+  );
+
+  return (
+    <div className="pixel-blast" aria-hidden="true">
+      {particles.map((particle, index) => (
+        <span
+          key={index}
+          style={{
+            '--angle': `${particle.angle}deg`,
+            '--distance': `${particle.distance}vmin`,
+            '--delay': `${particle.delay * -1}s`,
+            '--duration': `${particle.duration}s`,
+            '--size': `${particle.size}px`,
+            '--hue': particle.hue,
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default PixelBlast;

--- a/src/components/RotatingText.css
+++ b/src/components/RotatingText.css
@@ -3,7 +3,7 @@
   display: inline-grid;
   align-items: center;
   justify-items: center;
-  min-width: 12ch;
+  min-width: 14ch;
   font-weight: 600;
   color: #0f2725;
   text-transform: lowercase;

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,7 @@
   --ink: #0f2725;
   --muted: #5f7573;
   --border: #e4eeed;
+  --sticky-header-offset: clamp(6.5rem, 14vw, 9rem);
 }
 
 * {
@@ -51,7 +52,7 @@ a:focus-visible {
 .page__header {
   position: sticky;
   top: 0;
-  z-index: 2;
+  z-index: 3;
   background: #ffffff;
   border-bottom: 1px solid var(--border);
 }
@@ -122,7 +123,8 @@ a:focus-visible {
   align-items: center;
   gap: clamp(4rem, 10vw, 7rem);
   padding: clamp(4rem, 12vw, 8rem) clamp(1.5rem, 5vw, 3rem) clamp(6rem, 16vw, 10rem);
-  z-index: 1;
+  z-index: 2;
+  scroll-margin-top: var(--sticky-header-offset);
 }
 
 .section {
@@ -130,6 +132,7 @@ a:focus-visible {
   max-width: 1080px;
   display: grid;
   gap: clamp(1.8rem, 4vw, 2.6rem);
+  scroll-margin-top: calc(var(--sticky-header-offset) + 1.2rem);
 }
 
 .section__header {
@@ -175,7 +178,8 @@ a:focus-visible {
 
 .hero__card {
   position: relative;
-  width: min(100%, 520px);
+  width: 100%;
+  max-width: clamp(520px, 60vw, 680px);
   padding: clamp(2.6rem, 6vw, 4rem);
   border-radius: 28px;
   background: rgba(255, 255, 255, 0.88);
@@ -205,6 +209,7 @@ a:focus-visible {
   flex-wrap: wrap;
   gap: 0.6rem;
   align-items: center;
+  justify-content: center;
 }
 
 .hero__meta {
@@ -281,6 +286,13 @@ a:focus-visible {
   font-weight: 700;
 }
 
+.contact__subtitle {
+  margin: 0;
+  font-family: 'Plus Jakarta Sans', 'Space Grotesk', sans-serif;
+  font-size: 1rem;
+  color: rgba(15, 39, 37, 0.68);
+}
+
 .contact__form {
   display: grid;
   gap: 0.8rem;
@@ -352,6 +364,10 @@ a:focus-visible {
     justify-content: center;
   }
 
+  .hero__card {
+    max-width: min(100%, 520px);
+  }
+
   .hero__heading {
     justify-content: center;
   }
@@ -359,7 +375,6 @@ a:focus-visible {
   .contact__submit {
     justify-self: stretch;
   }
-}
 
   .page__footer-inner {
     justify-content: center;


### PR DESCRIPTION
## Summary
- add a reusable PixelBlast background component inspired by the requested effect and layer it with the existing liquid backdrop
- align the About, Services, Work, Blog, and Contact section headings with their matching navigation labels while preserving descriptive subtitles
- introduce scroll offsets so anchored navigation stops just above each section heading on all breakpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e16c2252fc8324919e16ffb90d017b