### PR TITLE
Add resize fallback when ResizeObserver is unavailable

### DIFF
--- a/src/components/PixelBlast.jsx
+++ b/src/components/PixelBlast.jsx
@@ -475,8 +475,16 @@ const PixelBlast = ({
     };
 
     resize();
-    const resizeObserver = new ResizeObserver(resize);
-    resizeObserver.observe(container);
+
+    let resizeObserver;
+    let resizeListenerAttached = false;
+    if (typeof window !== 'undefined' && 'ResizeObserver' in window) {
+      resizeObserver = new window.ResizeObserver(resize);
+      resizeObserver.observe(container);
+    } else {
+      window.addEventListener('resize', resize);
+      resizeListenerAttached = true;
+    }
 
     let clickIndex = 0;
     let currentTime = 0;
@@ -549,7 +557,8 @@ const PixelBlast = ({
     return () => {
       observer?.disconnect();
       cancelAnimationFrame(rafRef.current);
-      resizeObserver.disconnect();
+      resizeObserver?.disconnect();
+      if (resizeListenerAttached) window.removeEventListener('resize', resize);
       window.removeEventListener('pointerdown', handlePointerDown);
       window.removeEventListener('pointermove', handlePointerMove);
       gl.deleteBuffer(positionBuffer);


### PR DESCRIPTION
## Summary
- add feature detection before instantiating `ResizeObserver`
- fall back to a window resize listener when the observer is unavailable and clean up appropriately

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1b5333b1c832486112b191caf63ea